### PR TITLE
address confusion around payment for pageviews

### DIFF
--- a/contributor-lists/issa-list.mediawiki
+++ b/contributor-lists/issa-list.mediawiki
@@ -14,7 +14,7 @@ Website: http://issarice.com
 
 EA Forum user profile: http://effective-altruism.com/user/riceissa/
 
-Note: The arrangement with Issa is much more complicated because, in addition to creating content on Wikipedia, he does background research, helps with managing editors, etc.
+Note: The arrangement with Issa is much more complicated because, in addition to creating content on Wikipedia, he does background research, helps with managing editors, etc. However, notably ''he is not paid for pageviews on Wikipedia pages he writes''.
 
 Note 2: This page only includes payment data for Tax Year 2016. Payments for 2015 are not included here.
 


### PR DESCRIPTION
See https://en.wikipedia.org/w/index.php?title=Wikipedia:Articles_for_deletion/Form_1040_(2nd_nomination)&oldid=732305339

"This article was expanded by a paid editor who is getting paid on page hits by User:Vipul".
This "paid editor" might referring to User:Majesticfish, but it's good to be clear on this anyway.
